### PR TITLE
Updating 1-vnet-main to work with AzureRM 3.5.2 and Vnet module 4.0.

### DIFF
--- a/1-main-vnet/main.tf
+++ b/1-main-vnet/main.tf
@@ -6,15 +6,15 @@ variable "resource_group_name" {
   type = string
 }
 
-variable "location" {
+variable "vnet_location" {
   type    = string
   default = "eastus"
 }
 
 
 variable "vnet_cidr_range" {
-  type    = string
-  default = "10.0.0.0/16"
+  type    = list(string)
+  default = ["10.0.0.0/16"]
 }
 
 variable "subnet_prefixes" {
@@ -27,27 +27,42 @@ variable "subnet_names" {
   default = ["web", "database"]
 }
 
+variable "use_for_each" {
+  type    = bool
+  default = true
+}
+
 #############################################################################
 # PROVIDERS
 #############################################################################
 
 provider "azurerm" {
-  version = "~> 1.0"
+  version = "~> 3.0"
+  features {
+
+  }
 }
 
 #############################################################################
 # RESOURCES
 #############################################################################
 
+resource "azurerm_resource_group" "vnet_1" {
+  name     = var.resource_group_name
+  location = var.vnet_location
+}
+
 module "vnet-main" {
   source              = "Azure/vnet/azurerm"
-  resource_group_name = var.resource_group_name
-  location            = var.location
-  vnet_name           = var.resource_group_name
+  resource_group_name = azurerm_resource_group.vnet_1.name
+  vnet_location       = azurerm_resource_group.vnet_1.location
+  vnet_name           = azurerm_resource_group.vnet_1.name
   address_space       = var.vnet_cidr_range
   subnet_prefixes     = var.subnet_prefixes
   subnet_names        = var.subnet_names
   nsg_ids             = {}
+  use_for_each        = var.use_for_each
+
 
   tags = {
     environment = "dev"

--- a/1-main-vnet/main.tf
+++ b/1-main-vnet/main.tf
@@ -47,6 +47,7 @@ provider "azurerm" {
 # RESOURCES
 #############################################################################
 
+## note sure if resource groups were ever created by Vnet module, but they certainly aren't anymore.
 resource "azurerm_resource_group" "vnet_1" {
   name     = var.resource_group_name
   location = var.vnet_location

--- a/1-main-vnet/main.tf
+++ b/1-main-vnet/main.tf
@@ -36,8 +36,17 @@ variable "use_for_each" {
 # PROVIDERS
 #############################################################################
 
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+
+    }
+  }
+}
+
 provider "azurerm" {
-  version = "~> 3.0"
   features {
 
   }

--- a/3-vnet-peering/vnet-peering.tf
+++ b/3-vnet-peering/vnet-peering.tf
@@ -29,25 +29,40 @@ variable "sec_principal_id" {
 
 data "azurerm_subscription" "current" {}
 
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+
+    }
+    azuread = {
+      source = "hashicorp/azuread"
+    }
+  }
+}
 
 provider "azurerm" {
-  version = "~> 1.0"
   alias           = "security"
   subscription_id = var.sec_sub_id
   client_id       = var.sec_client_id
   client_secret   = var.sec_client_secret
   skip_provider_registration  = true
-  skip_credentials_validation = true
+  features {
+    
+  }
 }
 
 provider "azurerm" {
-  version = "~> 1.0"
   alias                       = "peering"
   subscription_id             = data.azurerm_subscription.current.subscription_id
   client_id                   = var.sec_client_id
   client_secret               = var.sec_client_secret
   skip_provider_registration  = true
-  skip_credentials_validation = true
+  
+  features {
+    
+  }
 }
 
 resource "azurerm_role_definition" "vnet-peering" {
@@ -66,7 +81,7 @@ resource "azurerm_role_definition" "vnet-peering" {
 
 resource "azurerm_role_assignment" "vnet" {
   scope              = module.vnet-main.vnet_id
-  role_definition_id = azurerm_role_definition.vnet-peering.id
+  role_definition_id = azurerm_role_definition.vnet-peering.role_definition_resource_id
   principal_id       = var.sec_principal_id
 }
 
@@ -76,6 +91,7 @@ resource "azurerm_virtual_network_peering" "main" {
   virtual_network_name      = module.vnet-main.vnet_name
   remote_virtual_network_id = var.sec_vnet_id
   provider                  = azurerm.peering
+  
 
   depends_on = [azurerm_role_assignment.vnet]
 }

--- a/4-remote-state-prep/main.tf
+++ b/4-remote-state-prep/main.tf
@@ -19,9 +19,20 @@ variable "naming_prefix" {
 ##################################################################################
 # PROVIDERS
 ##################################################################################
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+
+    }
+  }
+}
 
 provider "azurerm" {
-  version = "~> 1.0"
+  features {
+    
+  }
 }
 
 ##################################################################################
@@ -82,6 +93,8 @@ data "azurerm_storage_account_sas" "state" {
     create  = true
     update  = false
     process = false
+    filter = false
+    tag = false
   }
 }
 

--- a/7-azure-devops-workspaces/main.tf
+++ b/7-azure-devops-workspaces/main.tf
@@ -26,6 +26,11 @@ variable "subnet_names" {
   default = ["web", "database", "app"]
 }
 
+variable "use_for_each" {
+  type    = bool
+  default = true
+}
+
 locals {
   full_rg_name = "${terraform.workspace}-${var.resource_group_name}"
 }
@@ -34,8 +39,23 @@ locals {
 # PROVIDERS
 #############################################################################
 
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+
+    }
+    azuread = {
+      source = "hashicorp/azuread"
+    }
+  }
+}
+
 provider "azurerm" {
-  version = "~> 1.0"
+  features {
+    
+  }
 }
 
 #############################################################################
@@ -65,12 +85,13 @@ resource "azurerm_resource_group" "main" {
 module "vnet-main" {
   source              = "Azure/vnet/azurerm"
   resource_group_name = azurerm_resource_group.main.name
-  location            = var.location
+  vnet_location            = var.location
   vnet_name           = azurerm_resource_group.main.name
-  address_space       = var.vnet_cidr_range[terraform.workspace]
+  address_space       = [var.vnet_cidr_range[terraform.workspace]]
   subnet_prefixes     = data.template_file.subnet_prefixes[*].rendered
   subnet_names        = var.subnet_names
   nsg_ids             = {}
+  use_for_each = var.use_for_each
 
   tags = {
     environment = terraform.workspace

--- a/7-azure-devops-workspaces/vnet-peering.tf
+++ b/7-azure-devops-workspaces/vnet-peering.tf
@@ -29,25 +29,40 @@ variable "sec_principal_id" {
 
 data "azurerm_subscription" "current" {}
 
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
 
-provider "azurerm" {
-  version = "~> 1.0"
+    }
+    azuread = {
+      source = "hashicorp/azuread"
+    }
+  }
+}
+
+rovider "azurerm" {
   alias           = "security"
   subscription_id = var.sec_sub_id
   client_id       = var.sec_client_id
   client_secret   = var.sec_client_secret
   skip_provider_registration  = true
-  skip_credentials_validation = true
+  features {
+    
+  }
 }
 
 provider "azurerm" {
-  version = "~> 1.0"
   alias                       = "peering"
   subscription_id             = data.azurerm_subscription.current.subscription_id
   client_id                   = var.sec_client_id
   client_secret               = var.sec_client_secret
   skip_provider_registration  = true
-  skip_credentials_validation = true
+  
+  features {
+    
+  }
 }
 
 
@@ -67,7 +82,7 @@ resource "azurerm_role_definition" "vnet-peering" {
 
 resource "azurerm_role_assignment" "vnet" {
   scope              = module.vnet-main.vnet_id
-  role_definition_id = azurerm_role_definition.vnet-peering.id
+  role_definition_id = azurerm_role_definition.vnet-peering.role_definition_resource_id
   principal_id       = var.sec_principal_id
 }
 

--- a/8-app-remote-state/main.tf
+++ b/8-app-remote-state/main.tf
@@ -20,8 +20,18 @@ variable "naming_prefix" {
 # PROVIDERS
 ##################################################################################
 
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
 provider "azurerm" {
-  version = "~> 1.0"
+  features {
+    
+  }
 }
 
 ##################################################################################
@@ -82,6 +92,8 @@ data "azurerm_storage_account_sas" "state" {
     create  = true
     update  = false
     process = false
+    filter = false
+    tag = false
   }
 }
 
@@ -104,7 +116,7 @@ Add-Content -Value 'key = "terraform.tfstate"' -Path "backend-config.txt"
 Add-Content -Value 'sas_token = "${data.azurerm_storage_account_sas.state.sas}"' -Path "backend-config.txt"
 EOT
 
-    interpreter = ["PowerShell", "-Command"]
+    interpreter = ["pwsh", "-Command"]
   }
 }
 
@@ -122,4 +134,5 @@ output "resource_group_name" {
 
 output "shared_access_signature" {
   value = data.azurerm_storage_account_sas.state.sas
+  sensitive = true
 }

--- a/9-app-deploy/backend-config.txt
+++ b/9-app-deploy/backend-config.txt
@@ -1,4 +1,4 @@
-storage_account_name = "STORAGE_ACCOUNT_NAME"
+storage_account_name = "appitma18161"
 container_name = "terraform-state"
 key = "terraform.tfstate"
-sas_token = "SAS_TOKEN"
+sas_token = "empty"

--- a/9-app-deploy/main.tf
+++ b/9-app-deploy/main.tf
@@ -42,9 +42,19 @@ locals {
 #############################################################################
 # PROVIDERS
 #############################################################################
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
 
 provider "azurerm" {
-  version = "~> 1.0"
+  features {
+    
+  }
 }
 
 #############################################################################
@@ -116,7 +126,6 @@ resource "azurerm_lb" "app" {
 }
 
 resource "azurerm_lb_backend_address_pool" "app" {
-  resource_group_name = azurerm_resource_group.app.name
   loadbalancer_id     = azurerm_lb.app.id
   name                = "${local.prefix}-app"
 }

--- a/9-app-deploy/terraform.tfvars.example
+++ b/9-app-deploy/terraform.tfvars.example
@@ -1,8 +1,0 @@
-resource_group_name = "app"
-
-network_state = {
-    "sa" = "STORAGE_ACCOUNT_NAME"
-    "cn" = "CONTAINER_NAME"
-    "key" = "STATE_FILE_KEY"
-    "sts" = "SAS_TOKEN"
-}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Note: I am leaving this as it was because it was written but Ned1313 on the course below. However, I have updated most of his Terraform Configurations during my learning.
+# This code is definitely not 100% my own work, I am mostly keeping it here so I can refer back to it in the future.
+
 # Implementing-Terraform-on-Microsoft-Azure
 
 Welcome to Implementing Terraform on Microsoft Azure. These exercise files are meant to accompany my course on [Pluralsight](https://app.pluralsight.com/library/courses/implementing-terraform-microsoft-azure/).  The course was developed using version 0.12.10 of Terraform.  As far as I know there are no coming changes that will significantly impact the validity of these exercise files.  But I also don't control all the plug-ins, providers, and modules used by the configurations.


### PR DESCRIPTION
The title pretty much says it all. I am still learning Terraform so it is okay if this pull request is not excepted, but I already spent the time to get this main.tf file working on Azure Portal so I figured I might as well create a pull request.

The main differences is that the Vnet module has different required arguments (e.g. location changed to vnet_location) and user_for_each became a required argument sometime between now and Vnet module 4.0.0. 

Also, the Vnet module doesn't seem to create a resource group anymore, so I added a resource for that and used azurerm_resource_group.vnet_1.name for the resource_group_name and azurerm_resouce_group.vnet_1.location for the vnet_location. I did this so that the Vnet module would not run until the resource group was created.